### PR TITLE
Remove class variable warnings

### DIFF
--- a/app/helpers/spree/api/api_helpers_decorator.rb
+++ b/app/helpers/spree/api/api_helpers_decorator.rb
@@ -1,21 +1,13 @@
 # frozen_string_literal: true
 
 Spree::Api::ApiHelpers.module_eval do
-  @@review_attributes = [
+  mattr_reader :review_attributes, default: [
     :id, :product_id, :name, :location, :rating, :title, :review, :approved,
     :created_at, :updated_at, :user_id, :ip_address, :locale, :show_identifier,
     :verified_purchaser
   ]
 
-  @@feedback_review_attributes = [
+  mattr_reader :feedback_review_attributes, default: [
     :id, :user_id, :review_id, :rating, :comment, :created_at, :updated_at, :locale
   ]
-
-  def review_attributes
-    @@review_attributes
-  end
-
-  def feedback_review_attributes
-    @@feedback_review_attributes
-  end
 end


### PR DESCRIPTION
Braidio issue #1652: This gets rids of a couple of compiler warnings about toplevel class variables